### PR TITLE
Don't blindly lowercase point reasons

### DIFF
--- a/node_modules/hubot-plusplus/src/plusplus.coffee
+++ b/node_modules/hubot-plusplus/src/plusplus.coffee
@@ -45,7 +45,7 @@ module.exports = (robot) ->
     room = msg.message.room
 
     # do some sanitizing
-    reason = reason?.trim().toLowerCase()
+    reason = reason?.trim()
     name = (name.replace /(^\s*@)|([,:\s]*$)/g, "").trim().toLowerCase() if name
 
     # check whether a name was specified. use MRU if not


### PR DESCRIPTION
The people have spoken

```
- messing up those capital letters: -1 points
- un-captializing book titles: -1 points
- not respecting capitalization: -1 points
- not correctly capitalizing storedge: -1 points
- lower casing amy's "i": -1 points
```
