### PR TITLE
Allow "is also" to create a new factoid.

### DIFF
--- a/node_modules/hubot-scripts/src/scripts/factoid.coffee
+++ b/node_modules/hubot-scripts/src/scripts/factoid.coffee
@@ -44,7 +44,7 @@ class Factoids
       @robot.brain.data.factoids = @cache
       "Ok. #{input} is also #{val} "
     else
-      "No factoid for #{input}. It can't also be #{val} if it isn't already something."
+      this.setFactoid input, val
 
   setFactoid: (key, val) ->
     input = key


### PR DESCRIPTION
Because the distinction between the two is pretty obnoxious and I don't think there's a use case where this isn't an acceptable outcome.
